### PR TITLE
fixing 0-dim tensor (scalar) access

### DIFF
--- a/rationale_net/datasets/__init__.py
+++ b/rationale_net/datasets/__init__.py
@@ -1,1 +1,2 @@
 import rationale_net.datasets.full_beer_dataset
+import rationale_net.datasets.yelp_typos_dataset

--- a/rationale_net/datasets/yelp_typos_dataset.py
+++ b/rationale_net/datasets/yelp_typos_dataset.py
@@ -1,0 +1,69 @@
+import torch
+import torch.utils.data as data
+import gzip
+import rationale_net.utils.dataset as utils
+import tqdm
+import numpy as np
+import pickle
+import json
+from rationale_net.datasets.factory import RegisterDataset
+from rationale_net.datasets.abstract_dataset import AbstractDataset
+
+
+SMALL_TRAIN_SIZE = 800
+
+@RegisterDataset('yelp_typos')
+class YelpTyposDataset(AbstractDataset):
+
+    def __init__(self, args, word_to_indx, mode, max_length=250, stem='raw_data/yelp/yelp.disc'):
+        self.args= args
+        self.name = mode
+        self.objective = args.objective
+        self.dataset = []
+        self.word_to_indx  = word_to_indx
+        self.max_length = max_length
+        self.name_to_key = {'train':'train', 'dev':'heldout', 'test':'heldout'}
+        self.class_balance = {}
+        with gzip.open(stem+'.'+self.name_to_key[self.name]+'.txt.gz') as gfile:
+            lines = gfile.readlines()
+            lines = list(zip(range(len(lines)), lines))
+            if args.debug_mode:
+                lines = lines[:SMALL_TRAIN_SIZE]
+            elif self.name == 'dev':
+                lines = lines[:5000]
+            elif self.name == 'test':
+                lines = lines[5000:10000]
+            elif self.name == 'train':
+                lines = lines[0:20000]
+
+            for indx, line in tqdm.tqdm(enumerate(lines)):
+                uid, line_content = line
+                sample = self.processLine(line_content, indx)
+
+                if not sample['y'] in self.class_balance:
+                    self.class_balance[ sample['y'] ] = 0
+                self.class_balance[ sample['y'] ] += 1
+                sample['uid'] = uid
+                self.dataset.append(sample)
+            gfile.close()
+        print ("Class balance", self.class_balance)
+
+        if args.class_balance:
+            raise NotImplementedError("Yelp typo dataset doesn't support balanced sampling!")
+
+    ## Convert one line from yelp dataset to {Text, Tensor, Labels}
+    def processLine(self, line, i):
+        if isinstance(line, bytes):
+            line = line.decode()
+        label = line.split('\t')[0]
+        if self.objective == 'mse':
+            label = float(label)
+            self.args.num_class = 1
+        else:
+            label = int(label)
+            self.args.num_class = 2
+        token_seq = line.split('\t')[1].split()[:self.max_length]
+        text = " ".join(token_seq)
+        x =  utils.get_indices_tensor(token_seq, self.word_to_indx, self.max_length)
+        sample = {'text':text,'x':x, 'y':label, 'i':i}
+        return sample

--- a/rationale_net/utils/generic.py
+++ b/rationale_net/utils/generic.py
@@ -3,6 +3,8 @@ import pdb
 import argparse
 
 def tensor_to_numpy(tensor):
+    if tensor.data.shape == torch.Size([]):
+        return tensor.item()
     return tensor.data[0]
 
 class Namespace:

--- a/scripts/combine_with_labels.py
+++ b/scripts/combine_with_labels.py
@@ -1,0 +1,43 @@
+from random import shuffle
+from tqdm import tqdm
+import argparse
+
+def main(args):
+    mode = 'w'
+    if args.append:
+        mode = 'a'
+    with open(args.src0_path, 'r') as src0:
+        with open(args.src1_path, 'r') as src1:
+            with open(args.save_path, mode) as tgt:
+                data = []
+                zero_count = 0
+                print("Reading source 0")
+                for line in tqdm(src0):
+                    data.append('0\t'+line)
+                    zero_count += 1
+                one_count = 0
+                print("Reading source 1")
+                for line in tqdm(src1):
+                    data.append('1\t'+line)
+                    one_count += 1
+                print("Shuffling")
+                shuffle(data)
+                print("Writing to data file")
+                for sample in tqdm(data):
+                    tgt.write(sample)
+                print("Num w class 0: {}   Num w class 1: {} ".format(zero_count, one_count))
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description='Combine two files of line separated sentences into one file with binary labels distinguishing source file')
+    parser.add_argument('--src0_path', type=str, help='path to file with first style')
+    parser.add_argument('--src1_path', type=str, help='path to file with second style')
+    parser.add_argument('--save_path', type=str, help='path to save file')
+    parser.add_argument('--append', action='store_true', default=True, help='if results should be appended (instead of overwriting)')
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == '__main__':
+    args = get_args()
+    main(args)


### PR DESCRIPTION
New versions of PyTorch will require proper usage for accessing 0 dimensional Tensors:
`tensor.item()` instead of `tensor.data[0]`